### PR TITLE
fix: bug

### DIFF
--- a/apps/image-editor/package.json
+++ b/apps/image-editor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cocomite/tui-image-editor",
-  "version": "3.18.17",
+  "version": "3.18.18",
   "description": "TOAST UI ImageEditor",
   "keywords": [
     "nhn",

--- a/apps/image-editor/src/js/command.js
+++ b/apps/image-editor/src/js/command.js
@@ -257,15 +257,7 @@ export function changeSelection(commands, graphics, args) {
         if (commandId !== argId) {
           return;
         }
-        const a = { ...it.args[1] };
-        Object.keys(a)
-          .filter((key) => !['id'].includes(key))
-          .forEach((key) => {
-            if (arg[key]) {
-              a[key] = arg[key];
-            }
-          });
-        it.args[1] = a;
+        it.args[1] = { ...it.args[1], ...arg, id: it.args[1].id };
         return;
       }
       case commandNames.ADD_OBJECT: {

--- a/apps/image-editor/src/js/command.js
+++ b/apps/image-editor/src/js/command.js
@@ -261,7 +261,9 @@ export function changeSelection(commands, graphics, args) {
         Object.keys(a)
           .filter((key) => !['id'].includes(key))
           .forEach((key) => {
-            a[key] = arg[key];
+            if (arg[key]) {
+              a[key] = arg[key];
+            }
           });
         it.args[1] = a;
         return;

--- a/apps/image-editor/src/js/graphics.js
+++ b/apps/image-editor/src/js/graphics.js
@@ -1497,6 +1497,7 @@ class Graphics {
   _copyFabricObject(targetObject) {
     return new Promise((resolve) => {
       targetObject.clone((cloned) => {
+        cloned.iconType = targetObject.iconType;
         const shapeComp = this.getComponent(components.SHAPE);
         if (isShape(cloned)) {
           shapeComp.processForCopiedObject(cloned, targetObject);

--- a/apps/image-editor/src/js/imageEditor.js
+++ b/apps/image-editor/src/js/imageEditor.js
@@ -1171,7 +1171,7 @@ class ImageEditor {
     options = omitUndefined(options || {});
 
     this._setPositions(options);
-    this._setUniqueParameter(options, type);
+    this._setShapeType(options, type);
 
     return this.execute(commands.ADD_SHAPE, type, options);
   }
@@ -1556,7 +1556,7 @@ class ImageEditor {
     options = omitUndefined(options || {});
 
     this._setPositions(options);
-    options.iconType = type;
+    this._setShapeType(options, type);
 
     return this.execute(commands.ADD_ICON, type, options);
   }
@@ -1755,13 +1755,13 @@ class ImageEditor {
   }
 
   /**
-   * Set position
-   * @param {Object} options - Position options (left or top)
+   * Set shape type
+   * @param {Object} options - options for set shape type
    * @param {string} type - Shape type
    * @private
    */
-  _setUniqueParameter(options, type) {
-    options.iconType = type.iconType;
+  _setShapeType(options, type) {
+    options.iconType = type;
   }
 
   /**

--- a/apps/image-editor/src/js/imageEditor.js
+++ b/apps/image-editor/src/js/imageEditor.js
@@ -1171,6 +1171,7 @@ class ImageEditor {
     options = omitUndefined(options || {});
 
     this._setPositions(options);
+    this._setUniqueParameter(options, type);
 
     return this.execute(commands.ADD_SHAPE, type, options);
   }
@@ -1555,6 +1556,7 @@ class ImageEditor {
     options = omitUndefined(options || {});
 
     this._setPositions(options);
+    options.iconType = type;
 
     return this.execute(commands.ADD_ICON, type, options);
   }
@@ -1750,6 +1752,16 @@ class ImageEditor {
     if (isUndefined(options.top)) {
       options.top = centerPosition.top;
     }
+  }
+
+  /**
+   * Set position
+   * @param {Object} options - Position options (left or top)
+   * @param {string} type - Shape type
+   * @private
+   */
+  _setUniqueParameter(options, type) {
+    options.iconType = type.iconType;
   }
 
   /**


### PR DESCRIPTION
■現象
①スタンプをコピペして再編集するとエラーになる
②複数選択した状態でオブジェクト移動して再編集すると色が消える

■原因
①コピペした際にオブジェクトをクローンしているが、アイコンの場合、iconTypeフィールドが消えてしまっているので、loadCommandの際にエラーになっている
②移動した際に移動先オブジェクトの値を移動元オブジェクトで上書きしているが、移動先オブジェクトにfillフィールドがないため、undifiedで上書きされてしまっている

■修正内容
①clone後にclone前のiconTypeを付与する
②undefiedの際は上書きしない