### PR TITLE
fix: 複数選択して移動した時、一つしか移動しない問バグ修正

### DIFF
--- a/apps/image-editor/package.json
+++ b/apps/image-editor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cocomite/tui-image-editor",
-  "version": "3.18.19",
+  "version": "3.18.20",
   "description": "TOAST UI ImageEditor",
   "keywords": [
     "nhn",

--- a/apps/image-editor/src/js/command.js
+++ b/apps/image-editor/src/js/command.js
@@ -218,72 +218,73 @@ export function changeShape(commands, args) {
 }
 
 export function changeSelection(commands, graphics, args) {
-  const [[arg]] = args;
-  commands.forEach((it) => {
-    switch (it.name) {
-      case commandNames.ADD_TEXT: {
-        const commandId = +it.args[1].id;
-        const argId = +arg.id;
-        if (commandId !== argId) {
+  args[0].forEach((arg) => {
+    commands.forEach((it, i) => {
+      switch (it.name) {
+        case commandNames.ADD_TEXT: {
+          const commandId = +it.args[1].id;
+          const argId = +arg.id;
+          if (commandId !== argId) {
+            return;
+          }
+          const a = [it.args[0], { ...it.args[1] }];
+          a[0] = arg.text;
+          a[1] = {
+            ...a[1],
+            position: {
+              x: arg.left,
+              y: arg.top,
+            },
+            styles: {
+              ...a[1].styles,
+              angle:
+                graphics && graphics._objects[arg.id] ? graphics._objects[arg.id].angle : undefined,
+              fill: arg.fill,
+              fontFamily: arg.fontFamily,
+              fontSize: arg.fontSize,
+              fontStyle: arg.fontStyle,
+              fontWeight: arg.fontWeight,
+              underline: arg.underline,
+            },
+          };
+          it.args = a;
           return;
         }
-        const a = [it.args[0], { ...it.args[1] }];
-        a[0] = arg.text;
-        a[1] = {
-          ...a[1],
-          position: {
-            x: arg.left,
-            y: arg.top,
-          },
-          styles: {
-            ...a[1].styles,
-            angle:
-              graphics && graphics._objects[arg.id] ? graphics._objects[arg.id].angle : undefined,
-            fill: arg.fill,
-            fontFamily: arg.fontFamily,
-            fontSize: arg.fontSize,
-            fontStyle: arg.fontStyle,
-            fontWeight: arg.fontWeight,
-            underline: arg.underline,
-          },
-        };
-        it.args = a;
-        return;
-      }
-      case commandNames.ADD_ICON:
-      case commandNames.ADD_SHAPE: {
-        const commandId = +it.args[1].id;
-        const argId = +arg.id;
-        if (commandId !== argId) {
+        case commandNames.ADD_ICON:
+        case commandNames.ADD_SHAPE: {
+          const commandId = +it.args[1].id;
+          const argId = +arg.id;
+          if (commandId !== argId) {
+            return;
+          }
+          const a = { ...it.args[1] };
+          Object.keys(a)
+            .filter((key) => !['id'].includes(key))
+            .forEach((key) => {
+              if (arg[key]) {
+                a[key] = arg[key];
+              }
+            });
+          it.args[1] = a;
           return;
         }
-        const a = { ...it.args[1] };
-        Object.keys(a)
-          .filter((key) => !['id'].includes(key))
-          .forEach((key) => {
-            if (arg[key]) {
+        case commandNames.ADD_OBJECT: {
+          const commandId = +it.args[0].id;
+          const argId = +arg.id;
+          if (commandId !== argId) {
+            return;
+          }
+          const a = { ...it.args[0] };
+          Object.keys(a)
+            .filter((key) => !['id', 'type'].includes(key))
+            .forEach((key) => {
               a[key] = arg[key];
-            }
-          });
-        it.args[1] = a;
-        return;
-      }
-      case commandNames.ADD_OBJECT: {
-        const commandId = +it.args[0].id;
-        const argId = +arg.id;
-        if (commandId !== argId) {
+            });
+          it.args[0] = a;
           return;
         }
-        const a = { ...it.args[0] };
-        Object.keys(a)
-          .filter((key) => !['id', 'type'].includes(key))
-          .forEach((key) => {
-            a[key] = arg[key];
-          });
-        it.args[0] = a;
-        return;
       }
-    }
+    });
   });
 }
 


### PR DESCRIPTION
■原因
function changeSelectionでargs[0][0]のidに一致するオブジェクトしか上書き対象としていなかったが、
複数選択した場合には、args[0][1]以降にも値が入るため、args[0]でループさせて複数オブジェクト選択による移動にも対応する。

■補足
修正量は多いが、修正したのは、221行を削除し、222行目でargs[0]によるループを追加し、後はインデント修正のみ