### PR TITLE
テキストのコピペができない

### DIFF
--- a/apps/image-editor/package.json
+++ b/apps/image-editor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cocomite/tui-image-editor",
-  "version": "3.18.20",
+  "version": "3.18.21",
   "description": "TOAST UI ImageEditor",
   "keywords": [
     "nhn",

--- a/apps/image-editor/src/js/command.js
+++ b/apps/image-editor/src/js/command.js
@@ -176,7 +176,7 @@ export function createAddObjectCommand(command, args) {
             id: args[0].__fe_id,
             position: position,
             styles: styles,
-            isPaste: args[0].isPaste,
+            isCloned: args[0].isCloned,
           },
         ],
       };
@@ -256,7 +256,7 @@ export function changeSelection(commands, graphics, args) {
           let { left } = arg;
           let { top } = arg;
           // コピペして移動した場合のみ、位置がズレるので調整する
-          if (it.args[1].isPaste) {
+          if (it.args[1].isCloned) {
             left -= arg.width / 2;
             top -= arg.height / 2;
           }

--- a/apps/image-editor/src/js/command.js
+++ b/apps/image-editor/src/js/command.js
@@ -154,6 +154,32 @@ export function createAddObjectCommand(command, args) {
           },
         ],
       };
+    case 'i-text':
+      const position = {
+        x: args[0].left,
+        y: args[0].top,
+      };
+      const styles = {
+        angle: args[0].angle,
+        fill: args[0].fill,
+        fontFamily: args[0].fontFamily,
+        fontSize: args[0].fontSize,
+        fontStyle: args[0].fontStyle,
+        fontWeight: args[0].fontWeight,
+        underline: args[0].underline,
+      };
+      return {
+        name: commandNames.ADD_TEXT,
+        args: [
+          args[0].text,
+          {
+            id: args[0].__fe_id,
+            position: position,
+            styles: styles,
+            isPaste: args[0].isPaste,
+          },
+        ],
+      };
     default:
       return null;
   }
@@ -227,13 +253,20 @@ export function changeSelection(commands, graphics, args) {
           if (commandId !== argId) {
             return;
           }
+          let { left } = arg;
+          let { top } = arg;
+          // コピペして移動した場合のみ、位置がズレるので調整する
+          if (it.args[1].isPaste) {
+            left -= arg.width / 2;
+            top -= arg.height / 2;
+          }
           const a = [it.args[0], { ...it.args[1] }];
           a[0] = arg.text;
           a[1] = {
             ...a[1],
             position: {
-              x: arg.left,
-              y: arg.top,
+              x: left,
+              y: top,
             },
             styles: {
               ...a[1].styles,

--- a/apps/image-editor/src/js/graphics.js
+++ b/apps/image-editor/src/js/graphics.js
@@ -1498,6 +1498,9 @@ class Graphics {
     return new Promise((resolve) => {
       targetObject.clone((cloned) => {
         cloned.iconType = targetObject.iconType;
+        if (targetObject.text) {
+          cloned.isPaste = true;
+        }
         const shapeComp = this.getComponent(components.SHAPE);
         if (isShape(cloned)) {
           shapeComp.processForCopiedObject(cloned, targetObject);

--- a/apps/image-editor/src/js/graphics.js
+++ b/apps/image-editor/src/js/graphics.js
@@ -1497,10 +1497,9 @@ class Graphics {
   _copyFabricObject(targetObject) {
     return new Promise((resolve) => {
       targetObject.clone((cloned) => {
+        cloned.originId = targetObject.id;
         cloned.iconType = targetObject.iconType;
-        if (targetObject.text) {
-          cloned.isPaste = true;
-        }
+        cloned.isCloned = true;
         const shapeComp = this.getComponent(components.SHAPE);
         if (isShape(cloned)) {
           shapeComp.processForCopiedObject(cloned, targetObject);

--- a/apps/image-editor/src/js/graphics.js
+++ b/apps/image-editor/src/js/graphics.js
@@ -1497,7 +1497,7 @@ class Graphics {
   _copyFabricObject(targetObject) {
     return new Promise((resolve) => {
       targetObject.clone((cloned) => {
-        cloned.originId = targetObject.id;
+        cloned.originId = targetObject.id ? targetObject.id : targetObject.__fe_id;
         cloned.iconType = targetObject.iconType;
         cloned.isCloned = true;
         const shapeComp = this.getComponent(components.SHAPE);

--- a/apps/image-editor/src/js/imageEditor.js
+++ b/apps/image-editor/src/js/imageEditor.js
@@ -1953,6 +1953,7 @@ class ImageEditor {
             ? it.args.map((arg) => {
                 if (typeof arg === 'object') {
                   delete arg.id;
+                  delete arg.isPaste;
                   return arg;
                 } else {
                   return arg;

--- a/apps/image-editor/src/js/imageEditor.js
+++ b/apps/image-editor/src/js/imageEditor.js
@@ -1953,7 +1953,7 @@ class ImageEditor {
             ? it.args.map((arg) => {
                 if (typeof arg === 'object') {
                   delete arg.id;
-                  delete arg.isPaste;
+                  delete arg.isCloned;
                   return arg;
                 } else {
                   return arg;


### PR DESCRIPTION
■現象
①テキストがコピペできない
②コピペしたテキストを移動後にダンプ&ロードすると微妙に位置がズレる

■原因
①createAddObjectCommandでテキストを処理するようになっていない
②テキストの場合、left,top（x,y）は左上である必要があるが、
コピペした際のleft,topの値がオブジェクトの真ん中になっている
※他のオブジェクトはおそらく真ん中で問題ない

■対策
①createAddObjectCommandでテキストの場合の処理を追加
②コピペした場合には、オブジェクト左上の座標になるようにtopは-height/2、leftは-width/2分ずらす