### PR TITLE
複数選択したテキストを移動すると消えるバグ修正

### DIFF
--- a/apps/image-editor/package.json
+++ b/apps/image-editor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cocomite/tui-image-editor",
-  "version": "3.18.21",
+  "version": "3.18.22",
   "description": "TOAST UI ImageEditor",
   "keywords": [
     "nhn",

--- a/apps/image-editor/src/js/command.js
+++ b/apps/image-editor/src/js/command.js
@@ -313,7 +313,9 @@ export function changeSelection(commands, graphics, args) {
           Object.keys(a)
             .filter((key) => !['id', 'type'].includes(key))
             .forEach((key) => {
-              a[key] = arg[key];
+              if (arg[key]) {
+                a[key] = arg[key];
+              }
             });
           it.args[0] = a;
           return;

--- a/apps/image-editor/src/js/command.js
+++ b/apps/image-editor/src/js/command.js
@@ -261,7 +261,9 @@ export function changeSelection(commands, graphics, args) {
             top -= arg.height / 2;
           }
           const a = [it.args[0], { ...it.args[1] }];
-          a[0] = arg.text;
+          if (arg.text) {
+            a[0] = arg.text;
+          }
           a[1] = {
             ...a[1],
             position: {


### PR DESCRIPTION
■現象
複数選択したテキストを移動すると、dump&load後、移動したテキストが消える

■原因
複数選択した時、changeSelectionにtextフィールドが消えており、その状態でtextの値を上書きしているので、undefinedで上書きされるので、load後表示されなくなる。

■対策
存在している時のみ上書きするようにする
