### PR TITLE
fix: アイコンコピーで再編集できなくなるバグ修正

### DIFF
--- a/apps/image-editor/package.json
+++ b/apps/image-editor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cocomite/tui-image-editor",
-  "version": "3.18.24",
+  "version": "3.18.25",
   "description": "TOAST UI ImageEditor",
   "keywords": [
     "nhn",

--- a/apps/image-editor/src/js/imageEditor.js
+++ b/apps/image-editor/src/js/imageEditor.js
@@ -1171,6 +1171,7 @@ class ImageEditor {
     options = omitUndefined(options || {});
 
     this._setPositions(options);
+    this._setShapeType(options, type);
 
     return this.execute(commands.ADD_SHAPE, type, options);
   }
@@ -1555,6 +1556,7 @@ class ImageEditor {
     options = omitUndefined(options || {});
 
     this._setPositions(options);
+    this._setShapeType(options, type);
 
     return this.execute(commands.ADD_ICON, type, options);
   }
@@ -1750,6 +1752,16 @@ class ImageEditor {
     if (isUndefined(options.top)) {
       options.top = centerPosition.top;
     }
+  }
+
+  /**
+   * Set shape type
+   * @param {Object} options - options for set shape type
+   * @param {string} type - Shape type
+   * @private
+   */
+  _setShapeType(options, type) {
+    options.iconType = type;
   }
 
   /**


### PR DESCRIPTION
コピーした際にiconTypeが消えるので修正しました。
以前不要だと思って消した処理が必要だったので復元しました。